### PR TITLE
fix: display color icon in the browser

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -12,6 +12,9 @@
     "48": "icons/g48.png",
     "128": "icons/g128.png"
   },
+  "browser_action": {
+    "default_icon": "icons/g128.png"
+  },
   "default_locale": "en",
   "offline_enabled": true,
   "permissions": [


### PR DESCRIPTION
Adding 
```
  "browser_action": {
    "default_icon": "icons/g128.png"
  }
```
should display a color icon in the browser. 
Works fine in chrome & firefox, Not sure of opera. 
Hope it helps! Thanks 🙂 