### PR TITLE
fix: use singular 'day' for streaks of 1 day

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -293,11 +293,11 @@ function inject() {
                     totalContributionsText
                 ], [
                     'Longest streak',
-                    `${longestStreak.toLocaleString()} days`,
+                    `${longestStreak.toLocaleString()} ${longestStreak == 1 ? 'day' : 'days'}`,
                     longestStreakText
                 ], [
                     'Current streak',
-                    `${currentStreak.toLocaleString()} days`,
+                    `${currentStreak.toLocaleString()} ${currentStreak == 1 ? 'day' : 'days'}`,
                     currentStreakText
                 ]
             ];


### PR DESCRIPTION
I just noticed that there is a typo when the streak is only 1 day long, and the table says "1 days" instead of "1 day". This small PR fixes that.

![Table says "1 days" instead of "1 day"](https://user-images.githubusercontent.com/4038174/71926357-0d34ca00-318b-11ea-9635-8c7034cc4f92.png)

Thanks in advance 😄 